### PR TITLE
Implemented export to original files

### DIFF
--- a/Document/Tag.php
+++ b/Document/Tag.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\TranslationsBundle\Document;
+
+use ONGR\ElasticsearchBundle\Annotation as ES;
+use ONGR\ElasticsearchBundle\Document\AbstractDocument;
+
+/**
+ * Object used for translation tags.
+ * 
+ * @ES\Object()
+ */
+class Tag extends AbstractDocument
+{
+    /**
+     * @var string
+     * 
+     * @ES\Property(name="name", type="string")
+     */
+    private $name;
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+}

--- a/Document/Translation.php
+++ b/Document/Translation.php
@@ -31,9 +31,9 @@ class Translation extends AbstractDocument implements \JsonSerializable
     /**
      * @var string
      * 
-     * @ES\Property(name="group", type="string", index="not_analyzed")
+     * @ES\Property(name="tags", type="object", multiple=true, objectName="ONGRTranslationsBundle:Tag")
      */
-    private $group = 'default';
+    private $tags;
 
     /**
      * @var Message
@@ -48,6 +48,20 @@ class Translation extends AbstractDocument implements \JsonSerializable
      * @ES\Property(name="key", type="string", index="not_analyzed")
      */
     private $key;
+
+    /**
+     * @var string
+     *
+     * @ES\Property(name="path", type="string", index="not_analyzed")
+     */
+    private $path;
+
+    /**
+     * @var string
+     * 
+     * @ES\Property(name="format", type="string")
+     */
+    private $format;
 
     /**
      * @return string
@@ -66,23 +80,19 @@ class Translation extends AbstractDocument implements \JsonSerializable
     }
 
     /**
-     * @return string
+     * @param array $tags
      */
-    public function getGroup()
+    public function setTags($tags)
     {
-        if ($this->group === '') {
-            $this->group = 'default';
-        }
-
-        return $this->group;
+        $this->tags = $tags;
     }
 
     /**
-     * @param string $group
+     * @return array
      */
-    public function setGroup($group)
+    public function getTags()
     {
-        $this->group = $group;
+        return $this->tags;
     }
 
     /**
@@ -121,6 +131,7 @@ class Translation extends AbstractDocument implements \JsonSerializable
             [
                 'id' => $this->getId(),
                 'messages' => $this->getMessagesArray(),
+                'tags' => $this->getTagsArray(),
             ]
         );
     }
@@ -150,6 +161,38 @@ class Translation extends AbstractDocument implements \JsonSerializable
     }
 
     /**
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @param string $path
+     */
+    public function setPath($path)
+    {
+        $this->path = $path;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFormat()
+    {
+        return $this->format;
+    }
+
+    /**
+     * @param string $format
+     */
+    public function setFormat($format)
+    {
+        $this->format = $format;
+    }
+
+    /**
      * Returns messages as array.
      *
      * array (
@@ -166,5 +209,20 @@ class Translation extends AbstractDocument implements \JsonSerializable
         }
 
         return $result;
+    }
+
+    /**
+     * Returns tags array.
+     *
+     * @return array
+     */
+    private function getTagsArray()
+    {
+        return $this->tags !== null ? array_map(
+            function ($value) {
+                return $value->getName();
+            },
+            $this->tags
+        ) : [];
     }
 }

--- a/Resources/config/filters_container.yml
+++ b/Resources/config/filters_container.yml
@@ -35,13 +35,10 @@ parameters:
     ongr_translations.filter.single_term.class: ONGR\FilterManagerBundle\Filters\Widget\Choice\SingleTermChoice
     ongr_translations.filter.single_term.domain.request_field: domain
     ongr_translations.filter.single_term.domain.field: domain
-    ongr_translations.filter.single_term.group.request_field: group
-    ongr_translations.filter.single_term.group.field: group
 
     ongr_translations.filter.locale.class: ONGR\TranslationsBundle\Filter\LocaleFilter
     ongr_translations.filter.locale.request_field: locale
     ongr_translations.filter.locale.field: locale
-
 
     ongr_translations.filters_container.class: ONGR\FilterManagerBundle\Search\FiltersContainer
 
@@ -70,11 +67,7 @@ services:
         calls:
             - ["setRequestField", ["%ongr_translations.filter.single_term.domain.request_field%"]]
             - ["setField", ["%ongr_translations.filter.single_term.domain.field%"]]
-    ongr_translations.filter.single_term.group:
-            class: "%ongr_translations.filter.single_term.class%"
-            calls:
-                - ["setRequestField", ["%ongr_translations.filter.single_term.group.request_field%"]]
-                - ["setField", ["%ongr_translations.filter.single_term.group.field%"]]
+
     ongr_translations.filter.locale:
         class: "%ongr_translations.filter.locale.class%"
         calls:
@@ -91,6 +84,5 @@ services:
             - ["set", ["sort", "@ongr_translations.filter.sort"]]
             - ["set", ["search", "@ongr_translations.filter.match_search"]]
             - ["set", ["domain", "@ongr_translations.filter.single_term.domain"]]
-            - ["set", ["group", "@ongr_translations.filter.single_term.group"]]
             - ["set", ["locale", "@ongr_translations.filter.locale"]]
 

--- a/Resources/translations/ONGRTranslations.en.yml
+++ b/Resources/translations/ONGRTranslations.en.yml
@@ -3,16 +3,16 @@ label.group: Group
 label.key: Key
 label.locale: Locale
 label.message: Message
-label.sort: Sort:
-placeholder.search_for: Search for...
+label.sort: 'Sort:'
+placeholder.search_for: 'Search for...'
 save: Save
 close: Close
 filter.locale: Locale
 filter.domain: Domain
-filter.group: Group
 filter.sort: Sort
 filter.clear: Clear
-sort.message.asc: Message ASC
-sort.message.desc: Message DESC
-sort.key.asc: Key ASC
-sort.key.desc: Key DESC
+sort.message.asc: 'Message ASC'
+sort.message.desc: 'Message DESC'
+sort.key.asc: 'Key ASC'
+sort.key.desc: 'Key DESC'
+filter.group: Group

--- a/Resources/translations/ONGRTranslations.lt.yml
+++ b/Resources/translations/ONGRTranslations.lt.yml
@@ -3,16 +3,16 @@ label.group: Grupė
 label.key: Raktas
 label.locale: Localė
 label.message: Tekstas
-label.sort: Rikiuoti:
+label.sort: 'Rikiuoti:'
 placeholder.search_for: Ieškoti...
 save: Saugoti
 close: Uždaryti
 filter.locale: Localė
 filter.domain: Domenas
-filter.group: Grupė
 filter.sort: Rikiavimas
 filter.clear: Atšaukti
-sort.message.asc: Žinutė A-Ž
-sort.message.desc: Žinutė Ž-A
-sort.key.asc: Raktas A-Ž
-sort.key.desc: Raktas Ž-A
+sort.message.asc: 'Žinutė A-Ž'
+sort.message.desc: 'Žinutė Ž-A'
+sort.key.asc: 'Raktas A-Ž'
+sort.key.desc: 'Raktas Ž-A'
+filter.group: Grupė

--- a/Resources/views/List/list.html.twig
+++ b/Resources/views/List/list.html.twig
@@ -10,7 +10,6 @@
                     <thead>
                         <tr>
                             <th>{% trans from 'ONGRTranslations' %}label.domain{% endtrans %}</th>
-                            <th>{% trans from 'ONGRTranslations' %}label.group{% endtrans %}</th>
                             <th>{% trans from 'ONGRTranslations' %}label.key{% endtrans %}</th>
                     {% verbatim %}
                             <th ng-cloak ng-repeat="(locale, enabled) in locales" ng-show="locales[locale]">
@@ -22,9 +21,6 @@
 
                         <tr ng-cloak ng-repeat="trans in translations">
                             <td width="10%">{{ trans.domain }}</td>
-                            <td width="10%">
-                                <div inline translation="trans"></div>
-                            </td>
                             <td width="20%">{{ trans.key }}</td>
                             <td ng-repeat="(locale, enabled) in locales" ng-show="locales[locale]">
                                 <div inline translation="trans" locale="{{locale}}"></div>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -28,7 +28,6 @@
                             {% block filters %}
                                 {{ filter_macros.dropdown(filters_manager.filters.locale, true) }}
                                 {{ filter_macros.dropdown(filters_manager.filters.domain, true) }}
-                                {{ filter_macros.dropdown(filters_manager.filters.group, true) }}
                                 {{ filter_macros.dropdown(filters_manager.filters.sort, false) }}
                             {% endblock %}
 

--- a/Service/Export.php
+++ b/Service/Export.php
@@ -91,7 +91,13 @@ class Export
             foreach ($translations as $translation) {
                 /** @var Translation $translation */
                 foreach ($translation->getMessages() as $message) {
-                    $path = $translation->getPath() . '.' . $message->getLocale() . '.' . $translation->getFormat();
+                    $path = sprintf(
+                        '%s' . DIRECTORY_SEPARATOR . '%s.%s.%s',
+                        $translation->getPath(),
+                        $translation->getDomain(),
+                        $message->getLocale(),
+                        $translation->getFormat()
+                    );
                     $data[$path][$translation->getKey()] = $message->getMessage();
                 }
             }

--- a/Service/Export.php
+++ b/Service/Export.php
@@ -31,11 +31,6 @@ class Export
     private $exporter;
 
     /**
-     * @var string
-     */
-    private $destinationDir;
-
-    /**
      * @var LoadersContainer
      */
     private $loadersContainer;
@@ -56,7 +51,6 @@ class Export
     ) {
         $this->storage = $storage;
         $this->exporter = $exporter;
-        $this->destinationDir = $kernelRootDir . '/Resources/translations';
         $this->loadersContainer = $loadersContainer;
     }
 
@@ -68,10 +62,6 @@ class Export
      */
     public function export($locales = [], $domains = [])
     {
-        if (!file_exists($this->destinationDir)) {
-            mkdir($this->destinationDir, 0755, true);
-        }
-
         foreach ($this->getExportData($locales, $domains) as $file => $translations) {
             if (file_exists($file)) {
                 list($domain, $locale, $extension) = explode('.', $file);
@@ -101,8 +91,7 @@ class Export
             foreach ($translations as $translation) {
                 /** @var Translation $translation */
                 foreach ($translation->getMessages() as $message) {
-                    $fileName = $translation->getDomain() . '.' .  $message->getLocale() . '.yml';
-                    $path = $this->destinationDir . DIRECTORY_SEPARATOR .  $fileName;
+                    $path = $translation->getPath() . '.' . $message->getLocale() . '.' . $translation->getFormat();
                     $data[$path][$translation->getKey()] = $message->getMessage();
                 }
             }

--- a/Storage/ElasticsearchStorage.php
+++ b/Storage/ElasticsearchStorage.php
@@ -52,6 +52,7 @@ class ElasticsearchStorage implements StorageInterface
         if (!empty($locales)) {
             $search->addFilter(new TermsFilter('locale', $locales));
         }
+
         if (!empty($domains)) {
             $search->addFilter(new TermsFilter('domain', $domains));
         }
@@ -67,16 +68,17 @@ class ElasticsearchStorage implements StorageInterface
         foreach ($translations as $domain => $domainTrans) {
             /** @var Translation $document */
 
-            foreach ($domainTrans as $key => $keyTrans) {
+            foreach ($domainTrans['translations'] as $key => $keyTrans) {
                 $document = $this->getRepository()->createDocument();
                 $document->setDomain($domain);
                 $document->setKey($key);
+                $document->setPath($domainTrans['path']);
+                $document->setFormat($domainTrans['format']);
 
                 foreach ($keyTrans as $locale => $trans) {
                     $message = new Message();
                     $message->setLocale($locale);
                     $message->setMessage($trans);
-
                     $document->addMessage($message);
                 }
                 $this->getRepository()->getManager()->persist($document);

--- a/Tests/Functional/Service/ImportTest.php
+++ b/Tests/Functional/Service/ImportTest.php
@@ -56,7 +56,10 @@ class ImportTest extends WebTestCase
     {
         $importService = $this->getContainer()->get('ongr_translations.import');
 
-        $this->assertArraySubset($expectedTranslations['messages'], $importService->getTranslations()['messages']);
+        $this->assertArraySubset(
+            $expectedTranslations['messages'],
+            $importService->getTranslations()['messages']['translations']
+        );
     }
 
     /**

--- a/Tests/Unit/Document/TranslationTest.php
+++ b/Tests/Unit/Document/TranslationTest.php
@@ -31,8 +31,8 @@ class TranslationTest extends \PHPUnit_Framework_TestCase
         $message->setMessage('foo_message');
         $translation->addMessage($message);
 
-        $expectedJson = '{"domain":"foo_domain","group":"default","messages":{"en":"foo_message"},"key":null,'
-            . '"id":"10b9bf5859bce4052de0dac6c01324679d21cad0"}';
+        $expectedJson = '{"domain":"foo_domain","tags":[],"messages":{"en":"foo_message"},'
+            . '"key":null,"path":null,"format":null,"id":"10b9bf5859bce4052de0dac6c01324679d21cad0"}';
 
         $this->assertEquals($expectedJson, json_encode($translation), 'JSON strings should be equal');
     }

--- a/Tests/Unit/Service/ExportTest.php
+++ b/Tests/Unit/Service/ExportTest.php
@@ -39,31 +39,6 @@ class ExportTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * Test if global translations directory is created.
-     */
-    public function testTargetDirectoryIsCreated()
-    {
-        $expectedDir = 'Resources/translations';
-        /* @var $exportService Export */
-        $exportService = $this
-            ->getMockBuilder('ONGR\TranslationsBundle\Service\Export')
-            ->setConstructorArgs(
-                [
-                    $this->getLoadersContainerMock(),
-                    $this->getStorageMock(['read']),
-                    $this->getExporterMock(),
-                    vfsStream::url('root'),
-                ]
-            )
-            ->setMethods(null)
-            ->getMock();
-
-        $this->assertFalse($this->root->hasChild($expectedDir), 'Resources/translations directory should not exists.');
-        $exportService->export();
-        $this->assertTrue($this->root->hasChild($expectedDir), 'Resources/translations directory should exists.');
-    }
-
-    /**
      * Tests if correct data array is formed.
      */
     public function testGetExportData()
@@ -71,6 +46,8 @@ class ExportTest extends \PHPUnit_Framework_TestCase
         $translation = new Translation();
         $translation->setDomain('foo_domain');
         $translation->setKey('foo_key');
+        $translation->setPath('vfs://root/Resources/translations');
+        $translation->setFormat('yml');
         $message = new Message();
         $message->setLocale('foo_locale');
         $message->setMessage('foo_message');

--- a/Translation/Export/YmlExport.php
+++ b/Translation/Export/YmlExport.php
@@ -11,6 +11,8 @@
 
 namespace ONGR\TranslationsBundle\Translation\Export;
 
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Finder\Finder;
 use Symfony\Component\Yaml\Dumper;
 
 /**

--- a/Translation/Export/YmlExport.php
+++ b/Translation/Export/YmlExport.php
@@ -28,12 +28,16 @@ class YmlExport implements ExportInterface
      */
     public function export($file, $translations)
     {
-        $ymlDumper = new Dumper();
-        $ymlDumper->setIndentation(0);
-        $ymlContent = '';
-        $ymlContent .= $ymlDumper->dump($translations, 10);
-        $bytes = file_put_contents($file, $ymlContent);
+        if (pathinfo($file, PATHINFO_EXTENSION) === 'yml') {
+            $ymlDumper = new Dumper();
+            $ymlDumper->setIndentation(0);
+            $ymlContent = '';
+            $ymlContent .= $ymlDumper->dump($translations, 10);
+            $bytes = file_put_contents($file, $ymlContent);
 
-        return ($bytes !== false);
+            return ($bytes !== false);
+        }
+
+        return false;
     }
 }

--- a/Translation/Import/FileImport.php
+++ b/Translation/Import/FileImport.php
@@ -55,9 +55,7 @@ class FileImport
             $domainMessages = $messageCatalogue->all($domain);
 
             if (!empty($domainMessages)) {
-                $this->translations[$domain]['path'] = pathinfo($file->getPathname(), PATHINFO_DIRNAME)
-                    . DIRECTORY_SEPARATOR
-                    . explode('.', pathinfo($file->getPathname(), PATHINFO_BASENAME))[0];
+                $this->translations[$domain]['path'] = pathinfo($file->getPathname(), PATHINFO_DIRNAME);
                 $this->translations[$domain]['format'] = $file->getExtension();
 
                 foreach ($domainMessages as $key => $content) {

--- a/Translation/Import/FileImport.php
+++ b/Translation/Import/FileImport.php
@@ -50,11 +50,19 @@ class FileImport
         list($domain, $locale, $extension) = explode('.', $file->getFilename());
 
         if ($this->loadersContainer->has($extension)) {
-            /** @var MessageCatalogue $messageCatalogue */
+            /* @var MessageCatalogue $messageCatalogue */
             $messageCatalogue = $this->loadersContainer->get($extension)->load($file, $locale, $domain);
+            $domainMessages = $messageCatalogue->all($domain);
 
-            foreach ($messageCatalogue->all($domain) as $key => $content) {
-                $this->translations[$domain][$key][$locale] = $content;
+            if (!empty($domainMessages)) {
+                $this->translations[$domain]['path'] = pathinfo($file->getPathname(), PATHINFO_DIRNAME)
+                    . DIRECTORY_SEPARATOR
+                    . explode('.', pathinfo($file->getPathname(), PATHINFO_BASENAME))[0];
+                $this->translations[$domain]['format'] = $file->getExtension();
+
+                foreach ($domainMessages as $key => $content) {
+                    $this->translations[$domain]['translations'][$key][$locale] = $content;
+                }
             }
         }
 


### PR DESCRIPTION
Partially closes #14  and closes #16

Removed Groups from GUI, Tags are implemented but not visible yet. Now export command exports to original files (now just `yml`). Did not add bundle property yet, because on the spot I would have to extract short bundle name form path which is ridiculous (incoming refactoring later). Tests green