### PR TITLE
Updated filter manager dependency due incopatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "symfony/symfony": "~2.6",
         "ongr/elasticsearch-bundle": "~0.9",
-        "ongr/filter-manager-bundle": "~0.4",
+        "ongr/filter-manager-bundle": "~0.5",
         "friendsofsymfony/jsrouting-bundle": "~1.5"
     },
     "require-dev": {


### PR DESCRIPTION
Seems like with `~0.4` version we have a crash:

```
Uncaught PHP Exception Symfony\Component\Debug\Exception\UndefinedMethodException: "Attempted to call an undefined method named "isRelevant" of class "ONGR\ElasticsearchBundle\DSL\Filter\TermFilter"." at /{edited}/vendor/ongr/filter-manager-bundle/Filters/Widget/Choice/SingleTermChoice.php line 80
```

0.5 dependency requirement solves this.

Closes #53 