### PR TITLE
Add `select all` to missing translations.

### DIFF
--- a/Resources/translations/ONGRTranslations.en.yml
+++ b/Resources/translations/ONGRTranslations.en.yml
@@ -9,6 +9,7 @@ label.timestamp: Timestamps
 label.created_at: 'Created at'
 label.updated_at: 'Updated at'
 label.status: Status
+label.missing_locale.all: 'Select all'
 placeholder.search_for: 'Search for...'
 save: Save
 close: Close

--- a/Resources/translations/ONGRTranslations.lt.yml
+++ b/Resources/translations/ONGRTranslations.lt.yml
@@ -9,6 +9,7 @@ label.timestamp: 'Laiko žymės'
 label.created_at: 'Sukurtas'
 label.updated_at: 'Atnaujintas'
 label.status: 'Statusas'
+label.missing_locale.all: 'Parinkti visus'
 placeholder.search_for: Ieškoti...
 save: Saugoti
 close: Uždaryti


### PR DESCRIPTION
Closes #55.