### PR TITLE
Clean translation manager

### DIFF
--- a/Translation/TranslationManager.php
+++ b/Translation/TranslationManager.php
@@ -140,9 +140,6 @@ class TranslationManager
      */
     private function addObject($document, $options)
     {
-        $accessor = $this->getAccessor();
-        $objects = $accessor->getValue($document, $options['name']);
-
         $meta = $this->repository->getManager()->getMetadataCollector()
             ->getBundleMapping('ONGRTranslationsBundle:Translation');
         $objectClass = reset($meta)['aliases'][$options['name']]['namespace'];
@@ -150,7 +147,6 @@ class TranslationManager
         $object = new $objectClass();
         $this->setObjectProperties($object, $options['properties']);
 
-        $objects[] = $object;
         $this->updateTimestamp($object);
         $this->updateTimestamp($document);
     }


### PR DESCRIPTION
Remove unnecessary variables/method calls from `TranslationManager`.