### PR TITLE
Changed field names in ElasticsearchStorage

### DIFF
--- a/Storage/ElasticsearchStorage.php
+++ b/Storage/ElasticsearchStorage.php
@@ -50,11 +50,11 @@ class ElasticsearchStorage implements StorageInterface
             ->addQuery(new MatchAllQuery());
 
         if (!empty($locales)) {
-            $search->addFilter(new TermsFilter('locale', $locales));
+            $search->addFilter(new TermsFilter('messages.locale', $locales));
         }
 
         if (!empty($domains)) {
-            $search->addFilter(new TermsFilter('domain', $domains));
+            $search->addFilter(new TermsFilter('messages.domain', $domains));
         }
 
         return $this->getRepository()->execute($search, Repository::RESULTS_OBJECT);


### PR DESCRIPTION
Changed field names provided to `termFilter()` in `ElasticsearchStorage`. `locale` and `domain` fields are embedded in `Message`.

Closes #81 