### PR TITLE
[feature-clean-old] add option to clean unused translations

### DIFF
--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -35,8 +35,14 @@ class ImportCommand extends ContainerAwareCommand
             'l',
             InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
             'Import only the specific locales, leave blank to import all configured.'
-        );
-        $this->addArgument(
+        )
+        ->addOption(
+            'clean',
+            null,
+            InputOption::VALUE_NONE,
+            'Clean not found translations keys'
+        )
+        ->addArgument(
             'bundle',
             InputArgument::OPTIONAL,
             'Import translations for the specific bundle.'
@@ -58,6 +64,8 @@ class ImportCommand extends ContainerAwareCommand
             $locales = $this->getContainer()->getParameter('ongr_translations.locales');
         }
 
+        $clean = $input->getOption('clean');
+
         $import->setLocales($locales);
 
         $bundleNames = $input->getArgument('bundle');
@@ -78,8 +86,14 @@ class ImportCommand extends ContainerAwareCommand
                 null,
                 [$this->getContainer()->getParameter('kernel.root_dir') . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'translations']
             );
+
             $import->writeToStorage($domain, $translations);
             $output->writeln('<info>*** Importing bundles translation files ***</info>');
+
+            if (true === $clean) {
+                $output->writeln('<info>*** Cleaning old translation keys from elasticsearch ***</info>');
+                $import->cleanTranslations($translations);
+            }
 
             foreach ($configBundles as $configBundle) {
                 $import->importTranslationFiles(
@@ -87,7 +101,6 @@ class ImportCommand extends ContainerAwareCommand
                     $this->getContainer()->get('kernel')->locateResource('@'.$configBundle)
                 );
             }
-
 //            $output->writeln('<info>*** Importing component translation files ***</info>');
 //            $import->importBundlesTranslationFiles(
 //                $this->getContainer()->getParameter('ongr_translations.component_directories')

--- a/Command/ImportCommand.php
+++ b/Command/ImportCommand.php
@@ -70,41 +70,27 @@ class ImportCommand extends ContainerAwareCommand
 
         $bundleNames = $input->getArgument('bundle');
 
-        if ($bundleNames) {
-//            $output->writeln("<info>*** Importing {$bundleName} translation files ***</info>");
-//            $bundle = $this->getContainer()->get('kernel')->getBundle($bundleNames);
-//
-//            foreach ($bundleNames as $bundleName) {
-//                $dir = $this->getContainer()->get('kernel')->getBundle($bundleName);
-//                $import->importTranslationFiles($bundle);
-//            }
-        } else {
-            $output->writeln('<info>*** Importing application translation files ***</info>');
-            $domain = 'messages';
-            $translations = $import->getTranslationsFromFiles(
-                $domain,
-                null,
-                [$this->getContainer()->getParameter('kernel.root_dir') . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'translations']
+        $output->writeln('<info>*** Importing application translation files ***</info>');
+        $domain = 'messages';
+        $translations = $import->getTranslationsFromFiles(
+            $domain,
+            null,
+            [$this->getContainer()->getParameter('kernel.root_dir') . DIRECTORY_SEPARATOR . 'Resources' . DIRECTORY_SEPARATOR . 'translations']
+        );
+
+        $import->writeToStorage($domain, $translations);
+        $output->writeln('<info>*** Importing bundles translation files ***</info>');
+
+        if ($clean) {
+            $output->writeln('<info>*** Cleaning unused translation keys from elasticsearch ***</info>');
+            $import->cleanTranslations($translations);
+        }
+
+        foreach ($configBundles as $configBundle) {
+            $import->importTranslationFiles(
+                $configBundle,
+                $this->getContainer()->get('kernel')->locateResource('@'.$configBundle)
             );
-
-            $import->writeToStorage($domain, $translations);
-            $output->writeln('<info>*** Importing bundles translation files ***</info>');
-
-            if (true === $clean) {
-                $output->writeln('<info>*** Cleaning old translation keys from elasticsearch ***</info>');
-                $import->cleanTranslations($translations);
-            }
-
-            foreach ($configBundles as $configBundle) {
-                $import->importTranslationFiles(
-                    $configBundle,
-                    $this->getContainer()->get('kernel')->locateResource('@'.$configBundle)
-                );
-            }
-//            $output->writeln('<info>*** Importing component translation files ***</info>');
-//            $import->importBundlesTranslationFiles(
-//                $this->getContainer()->getParameter('ongr_translations.component_directories')
-//            );
         }
     }
 }

--- a/Service/Import/ImportManager.php
+++ b/Service/Import/ImportManager.php
@@ -92,7 +92,6 @@ class ImportManager
     {
         foreach ($translations as $keys) {
             foreach ($keys as $key => $transMeta) {
-
                 $search = $this->repository->createSearch();
                 $search->addQuery(new MatchQuery('key', $key));
                 $results = $this->repository->findDocuments($search);
@@ -116,6 +115,21 @@ class ImportManager
         }
 
         $this->manager->commit();
+    }
+
+    /**
+     * @param array $translations
+     */
+    public function cleanTranslations(array $translations)
+    {
+        $translationKeys    = array_keys($translations);
+        $storedTranslations = $this->repository->findBy([]);
+
+        foreach ($storedTranslations as $document) {
+            if (!in_array($document->getKey(), $translationKeys)) {
+                $this->repository->remove($document->getId());
+            }
+        }
     }
 
     /**


### PR DESCRIPTION
This PR introduces the `--clean` flag for the `ongr:translation:import` command. Running the `ongr:translation:import` command with the `--clean` flag will cause the removal of all translation keys from ES that are not present in any translation file(s) configured in the ongr.translations config anymore. 

This optional flag should be added to the command to be able to cleanup unneeded translations. Currently `ongr:es:index:{drop,create}` is part of our workflow, which is annoying and could be resolved by this change. Please review.